### PR TITLE
[FE / BE] 로그인한 유저 정보 조회 API, 닉네임 설정 기능

### DIFF
--- a/client/src/api/user.ts
+++ b/client/src/api/user.ts
@@ -1,0 +1,17 @@
+import axios from ".";
+
+const { REACT_APP_OAUTH_GITHUB_AUTH_SERVER } = process.env;
+
+if (!REACT_APP_OAUTH_GITHUB_AUTH_SERVER) {
+  throw new Error("환경 변수가 제대로 설정되지 않았습니다.");
+}
+
+export const getLoggedInUser = async () => {
+  try {
+    const res = await axios.get("/user/");
+    console.log(res.data);
+    // return res.data.isLogin;
+  } catch {
+    return false;
+  }
+};

--- a/client/src/api/user.ts
+++ b/client/src/api/user.ts
@@ -14,3 +14,12 @@ export const getLoggedInUser = async () => {
     return null;
   }
 };
+
+export const updateNickname = async (nickname: string) => {
+  try {
+    const res = await axios.patch("/user/nickname", { nickname });
+    return res.data;
+  } catch {
+    throw new Error("닉네임 설정 오류");
+  }
+};

--- a/client/src/api/user.ts
+++ b/client/src/api/user.ts
@@ -9,9 +9,8 @@ if (!REACT_APP_OAUTH_GITHUB_AUTH_SERVER) {
 export const getLoggedInUser = async () => {
   try {
     const res = await axios.get("/user/");
-    console.log(res.data);
-    // return res.data.isLogin;
+    return res.data;
   } catch {
-    return false;
+    return null;
   }
 };

--- a/client/src/components/Input/index.tsx
+++ b/client/src/components/Input/index.tsx
@@ -21,7 +21,7 @@ const Input = ({ type, width, placeholder, disabled, value, setValue, handleKeyP
         width: ${width};
       `}
       type={type}
-      value={value ?? ""}
+      value={value}
       placeholder={placeholder}
       disabled={disabled ?? false}
       onChange={e => setValue(e.target.value)}

--- a/client/src/components/Modal/NickNameSetting/index.tsx
+++ b/client/src/components/Modal/NickNameSetting/index.tsx
@@ -4,12 +4,27 @@ import Input from "../../Input";
 import Button from "../../Button";
 import { useState } from "react";
 
-const NickNameSetting = () => {
+interface NickNameSettingProps {
+  closeModal: () => void;
+}
+
+const NickNameSetting = ({ closeModal }: NickNameSettingProps) => {
   const [nickName, setNickName] = useState<string>("");
+
+  const handleSubmitButton = () => {
+    if (nickName === "") {
+      alert("닉네임을 입력하세요.");
+      return;
+    }
+    // 닉네임 설정 api
+
+    closeModal();
+  };
+
   return (
     <>
-      <Input type="text" placeholder="" setValue={setNickName} />
-      <Button buttonType="확인" handleClick={() => {}} />
+      <Input type="text" placeholder="" value={nickName} setValue={setNickName} />
+      <Button buttonType="확인" handleClick={handleSubmitButton} />
     </>
   );
 };

--- a/client/src/components/Modal/NickNameSetting/index.tsx
+++ b/client/src/components/Modal/NickNameSetting/index.tsx
@@ -3,6 +3,7 @@
 import Input from "../../Input";
 import Button from "../../Button";
 import { useState } from "react";
+import { updateNickname } from "../../../api/user";
 
 interface NickNameSettingProps {
   closeModal: () => void;
@@ -16,7 +17,12 @@ const NickNameSetting = ({ closeModal }: NickNameSettingProps) => {
       alert("닉네임을 입력하세요.");
       return;
     }
-    // 닉네임 설정 api
+
+    updateNickname(nickName).catch(err => {
+      alert("닉네임 설정에 실패하였습니다.");
+      return;
+    });
+    alert("닉네임 설정이 완료되었습니다.");
 
     closeModal();
   };

--- a/client/src/components/Modal/index.tsx
+++ b/client/src/components/Modal/index.tsx
@@ -22,8 +22,12 @@ const Modal = ({ ModalType, user, gameId, roomName, closeModal }: ModalProps) =>
 
   switch (ModalType) {
     case "닉네임 설정":
-      modalTitle = "닉네임 설정";
-      content = <NickNameSetting />;
+      if (!closeModal) {
+        console.error("no props");
+      } else {
+        modalTitle = "닉네임 설정";
+        content = <NickNameSetting closeModal={closeModal} />;
+      }
       break;
     case "방 설정":
       if (!closeModal) {

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -4,13 +4,14 @@ import App from "./App";
 import { Global, ThemeProvider } from "@emotion/react";
 import { globalStyle } from "./styles/global";
 import theme from "./styles/theme";
+import { RecoilRoot } from "recoil";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 root.render(
-  <>
+  <RecoilRoot>
     <Global styles={globalStyle} />
     <ThemeProvider theme={theme}>
       <App />
     </ThemeProvider>
-  </>
+  </RecoilRoot>
 );

--- a/client/src/pages/lobby/index.tsx
+++ b/client/src/pages/lobby/index.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import * as style from "./styles";
 import { Page } from "../../components/Page";
 import Profile from "../../components/Profile";
@@ -10,15 +10,27 @@ import * as dummy from "../dummy";
 import { useRecoilState } from "recoil";
 import { userState } from "../../recoil/user";
 import { getLoggedInUser } from "../../api/user";
+import Modal from "../../components/Modal";
 
 const LobbyPage: React.FC = () => {
   const [user, setUser] = useRecoilState(userState);
+  const [nicknameModalOpen, setNicknameModalOpen] = useState<boolean>(false);
+
+  const closeModal = () => {
+    setNicknameModalOpen(false);
+  };
 
   useEffect(() => {
     getLoggedInUser().then(res => {
       setUser(res);
     });
   }, []);
+
+  useEffect(() => {
+    if (!user) return;
+
+    if (!user.nickname) setNicknameModalOpen(true);
+  }, [user]);
 
   return (
     <Page>
@@ -32,6 +44,7 @@ const LobbyPage: React.FC = () => {
           <Chatting />
         </div>
       </div>
+      {nicknameModalOpen && <Modal ModalType="닉네임 설정" closeModal={closeModal} />}
     </Page>
   );
 };

--- a/client/src/pages/lobby/index.tsx
+++ b/client/src/pages/lobby/index.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import React from "react";
+import React, { useEffect } from "react";
 import * as style from "./styles";
 import { Page } from "../../components/Page";
 import Profile from "../../components/Profile";
@@ -7,9 +7,17 @@ import UserList from "../../components/UserList";
 import Chatting from "../../components/Chatting";
 import RoomList from "../../components/RoomList";
 import * as dummy from "../dummy";
+import { useRecoilState } from "recoil";
+import { userState } from "../../recoil/user";
+import { getLoggedInUser } from "../../api/user";
 
 const LobbyPage: React.FC = () => {
-  // user 정보 로직
+  const [user, setUser] = useRecoilState(userState);
+
+  useEffect(() => {
+    // getuser
+    getLoggedInUser();
+  }, []);
 
   return (
     <Page>

--- a/client/src/pages/lobby/index.tsx
+++ b/client/src/pages/lobby/index.tsx
@@ -15,8 +15,9 @@ const LobbyPage: React.FC = () => {
   const [user, setUser] = useRecoilState(userState);
 
   useEffect(() => {
-    // getuser
-    getLoggedInUser();
+    getLoggedInUser().then(res => {
+      setUser(res);
+    });
   }, []);
 
   return (

--- a/client/src/recoil/user.ts
+++ b/client/src/recoil/user.ts
@@ -1,0 +1,7 @@
+import { User } from "@dto";
+import { atom } from "recoil";
+
+export const userState = atom<User | null>({
+  key: "user",
+  default: null,
+});

--- a/server/src/modules/user/user.controller.ts
+++ b/server/src/modules/user/user.controller.ts
@@ -38,7 +38,6 @@ export class UserController {
   @UseGuards(AccessTokenGuard)
   @Patch("/nickname")
   async patchNickname(@Req() req: RequestWithAccessToken, @Body() { nickname }: { nickname: string }) {
-    console.log(req.user, nickname);
     return this.userService.updateUserNickname(req.user.userId, nickname);
   }
 }

--- a/server/src/modules/user/user.controller.ts
+++ b/server/src/modules/user/user.controller.ts
@@ -20,7 +20,6 @@ export class UserController {
   @UseGuards(AccessTokenGuard)
   @Get("/")
   async getLoggedInUser(@Req() req: RequestWithAccessToken) {
-    console.log("LoggedIn:", req.user);
     return this.userService.findUser(req.user.userId);
   }
 

--- a/server/src/modules/user/user.controller.ts
+++ b/server/src/modules/user/user.controller.ts
@@ -36,13 +36,9 @@ export class UserController {
   }
 
   @UseGuards(AccessTokenGuard)
-  @Patch("/nickname/:userId")
-  async patchNickname(
-    @Param("userId", ParseIntPipe) userId: number,
-    @Req() req: RequestWithAccessToken,
-    @Body() { nickname }: { nickname: string }
-  ) {
-    if (req.user.userId != userId) throw new UnauthorizedException();
-    return this.userService.updateUserNickname(userId, nickname);
+  @Patch("/nickname")
+  async patchNickname(@Req() req: RequestWithAccessToken, @Body() { nickname }: { nickname: string }) {
+    console.log(req.user, nickname);
+    return this.userService.updateUserNickname(req.user.userId, nickname);
   }
 }

--- a/server/src/modules/user/user.controller.ts
+++ b/server/src/modules/user/user.controller.ts
@@ -17,11 +17,20 @@ import { UserService } from "./user.service";
 export class UserController {
   constructor(private userService: UserService) {}
 
+  @UseGuards(AccessTokenGuard)
+  @Get("/")
+  async getLoggedInUser(@Req() req: RequestWithAccessToken) {
+    console.log("LoggedIn:", req.user);
+    return this.userService.findUser(req.user.userId);
+  }
+
+  @UseGuards(AccessTokenGuard)
   @Get("/list")
   async getUserList() {
     return this.userService.findAllUser();
   }
 
+  @UseGuards(AccessTokenGuard)
   @Get("/:userId")
   async getUser(@Param("userId", ParseIntPipe) userId: number) {
     return this.userService.findUser(userId);


### PR DESCRIPTION
## 작업 내용
- 접속중인 유저 정보 조회 api 작성
- 유저 정보 수정 api에서 params 삭제 -> access token의 user로 find
- recoil 세팅 및 로비에서 유저 정보를 조회하여 전역 상태로 저장
- 닉네임이 null이면 모달을 띄우도록 로직 설정. 닉네임 설정 api 연결

## 전달 사항
-

## 참고 사항
- #56 
