### PR TITLE
[BE] API 구현

### DIFF
--- a/server/src/app.gateway.ts
+++ b/server/src/app.gateway.ts
@@ -43,7 +43,6 @@ export class AppGateway implements OnGatewayInit, OnGatewayConnection, OnGateway
 
     if (!user) socket.disconnect();
 
-    console.log("here");
     socket.join("lobby");
 
     const userPublicInfo = {

--- a/server/src/app.gateway.ts
+++ b/server/src/app.gateway.ts
@@ -34,14 +34,15 @@ export class AppGateway implements OnGatewayInit, OnGatewayConnection, OnGateway
   }
 
   async handleConnection(@ConnectedSocket() socket: Socket) {
-    const jwtAccessToken = socket.handshake.query["jwt-access-token"] as string;
-    socket.join("lobby");
-
     const userId = Number(socket.handshake.query["user-id"]);
 
     const user = await this.prisma.user.findUnique({
       where: { userId },
     });
+
+    if (!user) socket.disconnect();
+
+    socket.join("lobby");
 
     const userPublicInfo = {
       email: user.email,

--- a/server/src/modules/chat/chat.gateway.ts
+++ b/server/src/modules/chat/chat.gateway.ts
@@ -30,8 +30,10 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     const { message, sendTime } = data;
     const userInfo = JSON.parse(await this.redis.hget(RedisTableName.SOCKET_ID_TO_USER_INFO, socket.id));
 
+    console.log(userInfo);
+
     socket.to("lobby").emit("chat/lobby", {
-      sender: userInfo.name,
+      sender: userInfo.nickname,
       message,
       sendTime,
     });
@@ -43,7 +45,7 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     const userInfo = JSON.parse(await this.redis.hget(RedisTableName.SOCKET_ID_TO_USER_INFO, socket.id));
 
     socket.to(userInfo.roomId).emit("chat/room", {
-      sender: userInfo.name,
+      sender: userInfo.nickname,
       message,
       sendTime,
     });

--- a/server/src/modules/game-room/game-room.controller.ts
+++ b/server/src/modules/game-room/game-room.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, ForbiddenException, Get, Param, ParseIntPipe } from "@nestjs/common";
+import { Controller } from "@nestjs/common";
 import { GameRoomService } from "./game-room.service";
 
-@Controller("game")
+@Controller("game-room")
 export class GameRoomController {
   constructor(private gameService: GameRoomService) {}
 }

--- a/server/src/modules/game-room/game-room.gateway.ts
+++ b/server/src/modules/game-room/game-room.gateway.ts
@@ -79,7 +79,7 @@ export class GameroomGateway implements OnGatewayInit, OnGatewayConnection, OnGa
     const room = JSON.parse(await this.redis.hget(RedisTableName.GAME_ROOMS, roomId));
 
     if (!room) {
-      socket.emit("game-room/join-failed", {
+      socket.emit("game-room/error", {
         message: "the room does not exist",
       });
       return;
@@ -87,7 +87,7 @@ export class GameroomGateway implements OnGatewayInit, OnGatewayConnection, OnGa
 
     // 잘못된 비밀번호 입력
     if (room.isPrivate && room.password !== password) {
-      socket.emit("game-room/join-failed", {
+      socket.emit("game-room/error", {
         message: "wrong password",
       });
       return;
@@ -95,7 +95,7 @@ export class GameroomGateway implements OnGatewayInit, OnGatewayConnection, OnGa
 
     // 방 정원 초과
     if (room.participants.length + 1 > room.maximumPeople) {
-      socket.emit("game-room/join-failed", {
+      socket.emit("game-room/error", {
         message: "the room is full",
       });
       return;

--- a/server/src/modules/game-room/game-room.gateway.ts
+++ b/server/src/modules/game-room/game-room.gateway.ts
@@ -118,7 +118,6 @@ export class GameroomGateway implements OnGatewayInit, OnGatewayConnection, OnGa
   @SubscribeMessage("game-room/exit")
   async exit(@ConnectedSocket() socket: Socket) {
     const roomId = getRoomId(socket);
-    if (roomId === "lobby") return;
     const room = JSON.parse(await this.redis.hget(RedisTableName.GAME_ROOMS, roomId));
 
     // 유저를 방에서 제거

--- a/server/src/modules/game/game.controller.ts
+++ b/server/src/modules/game/game.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, ForbiddenException, Get, Param, ParseIntPipe } from "@nestjs/common";
+import { Controller, Get, Param, ParseIntPipe } from "@nestjs/common";
 import { GameService } from "./game.service";
 
 @Controller("game")
@@ -10,8 +10,8 @@ export class GameController {
     return this.gameService.findAllGame();
   }
 
-  @Get("/:gameId")
-  async getGame(@Param("gameId", ParseIntPipe) gameId: number) {
+  @Get("/:game-id")
+  async getGame(@Param("game-id", ParseIntPipe) gameId: number) {
     return this.gameService.findGame(gameId);
   }
 }

--- a/server/src/modules/user/user.controller.ts
+++ b/server/src/modules/user/user.controller.ts
@@ -3,29 +3,26 @@ import { RequestWithAccessToken } from "express";
 import { AccessTokenGuard } from "../jwt/jwt-access-token.guard";
 import { UserService } from "./user.service";
 
+@UseGuards(AccessTokenGuard)
 @Controller("user")
 export class UserController {
   constructor(private userService: UserService) {}
 
-  @UseGuards(AccessTokenGuard)
   @Get("/")
   async getLoggedInUser(@Req() req: RequestWithAccessToken) {
     return this.userService.findUser(req.user.userId);
   }
 
-  @UseGuards(AccessTokenGuard)
   @Get("/list")
   async getUserList() {
     return this.userService.findAllUser();
   }
 
-  @UseGuards(AccessTokenGuard)
   @Get("/:user-id")
   async getUser(@Param("user-id", ParseIntPipe) userId: number) {
     return this.userService.findUser(userId);
   }
 
-  @UseGuards(AccessTokenGuard)
   @Patch("/nickname")
   async patchNickname(@Req() req: RequestWithAccessToken, @Body("nickname") nickname: string) {
     return this.userService.updateUserNickname(req.user.userId, nickname);

--- a/server/src/modules/user/user.controller.ts
+++ b/server/src/modules/user/user.controller.ts
@@ -33,7 +33,7 @@ export class UserController {
 
   @UseGuards(AccessTokenGuard)
   @Patch("/profile-image")
-  async patchProfile(@Req() req: RequestWithAccessToken, @Body("profileImage") profileImage: string) {
+  async patchProfile(@Req() req: RequestWithAccessToken, @Body("profile-image") profileImage: string) {
     return this.userService.updateUserProfileImage(req.user.userId, profileImage);
   }
 }

--- a/server/src/modules/user/user.controller.ts
+++ b/server/src/modules/user/user.controller.ts
@@ -20,14 +20,20 @@ export class UserController {
   }
 
   @UseGuards(AccessTokenGuard)
-  @Get("/:userId")
-  async getUser(@Param("userId", ParseIntPipe) userId: number) {
+  @Get("/:user-id")
+  async getUser(@Param("user-id", ParseIntPipe) userId: number) {
     return this.userService.findUser(userId);
   }
 
   @UseGuards(AccessTokenGuard)
   @Patch("/nickname")
-  async patchNickname(@Req() req: RequestWithAccessToken, @Body() { nickname }: { nickname: string }) {
+  async patchNickname(@Req() req: RequestWithAccessToken, @Body("nickname") nickname: string) {
     return this.userService.updateUserNickname(req.user.userId, nickname);
+  }
+
+  @UseGuards(AccessTokenGuard)
+  @Patch("/profile-image")
+  async patchProfile(@Req() req: RequestWithAccessToken, @Body("profileImage") profileImage: string) {
+    return this.userService.updateUserProfileImage(req.user.userId, profileImage);
   }
 }

--- a/server/src/modules/user/user.gateway.ts
+++ b/server/src/modules/user/user.gateway.ts
@@ -12,14 +12,13 @@ import Redis from "ioredis";
 import { Server, Socket } from "socket.io";
 import { RedisTableName } from "src/constants/redis-table-name";
 import { redisRecordToObject } from "util/convert";
-import { PrismaService } from "../prisma/prisma.service";
 
 @WebSocketGateway(4001, { transports: ["websocket"], namespace: "/" })
 export class UserGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer() public server: Server;
   private logger = new Logger("Chat Gateway");
 
-  constructor(private jwt: JwtService, private prisma: PrismaService, @Inject("RedisProvider") private redis: Redis) {}
+  constructor(@Inject("RedisProvider") private redis: Redis) {}
 
   afterInit(server: Server) {
     // 매 초마다 모든 유저들에게 접속 중인 유저 정보 전송

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -26,14 +26,17 @@ export class UserService {
     return this.prisma.user.findMany({ select: getUserOption });
   }
 
-  async updateUserNickname(id: number, nickname: string) {
+  async updateUserNickname(userId: number, nickname: string) {
     return this.prisma.user.update({
-      where: {
-        userId: id,
-      },
-      data: {
-        nickname,
-      },
+      where: { userId },
+      data: { nickname },
+    });
+  }
+
+  async updateUserProfileImage(userId: number, profileImage: string) {
+    return this.prisma.user.update({
+      where: { userId },
+      data: { profileImage },
     });
   }
 }


### PR DESCRIPTION
## 작업 내용

- Query, Params 네이밍 컨벤션 통일
- 소켓 인증 로직 삭제
- 유저 프로필 변경 API
- socket disconnect시 서버가 터지는 문제 해결
- chat gateway 에서 user.nickname 대신 user.name을 보내는 버그 수정

## 전달 사항

- 클라이언트 측에서 소켓 연결할 때 query : {'user-id': 23} 형식으로 query를 넘겨줘야 합니다!

## 참고 사항

- #60 
