### PR TITLE
[FE] 커스텀 스크롤바 구현

### DIFF
--- a/client/src/components/Chatting/ChatLog/styles.ts
+++ b/client/src/components/Chatting/ChatLog/styles.ts
@@ -8,7 +8,7 @@ export const ChatLogContainerStyle = css`
   padding: 0.75rem;
   box-sizing: border-box;
   box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.2);
-  overflow-y: scroll;
+  overflow-y: overlay;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;

--- a/client/src/components/RoomList/styles.ts
+++ b/client/src/components/RoomList/styles.ts
@@ -39,7 +39,7 @@ export const roomListStyle = (theme: Theme) => css`
   box-sizing: border-box;
   padding: 1.5rem;
   border-radius: 10px;
-  overflow-y: scroll;
+  overflow-y: overlay;
 
   box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.2);
   background-color: ${theme.colors.secondary};

--- a/client/src/components/UserList/UserTable/styles.ts
+++ b/client/src/components/UserList/UserTable/styles.ts
@@ -6,7 +6,7 @@ export const TableContainerStyle = (theme: Theme) => css`
   width: inherit;
   border-radius: 0.75rem;
   flex-grow: 1;
-  padding: 1.5rem 2rem 2rem 2rem;
+  padding: 1.5rem 0.5rem 2rem 0.5rem;
   box-sizing: border-box;
   box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.2);
 
@@ -22,7 +22,9 @@ export const TableRankContainerStyle = css`
 `;
 
 export const TableStyle = css`
-  overflow-y: scroll;
+  overflow-y: overlay;
+  padding: 0 1.5rem 0 1.5rem;
+  box-sizing: border-box;
   height: 100%;
 `;
 

--- a/client/src/styles/global.ts
+++ b/client/src/styles/global.ts
@@ -173,4 +173,20 @@ export const globalStyle = css`
     font-family: "LINESeedKR";
     font-size: 16px;
   }
+
+  body {
+    overflow-y: overlay;
+  }
+
+  ::-webkit-scrollbar {
+    width: 1rem;
+  }
+
+  /* scrollbar itself */
+  ::-webkit-scrollbar-thumb {
+    background-color: #babac0;
+    background-clip: padding-box;
+    border-radius: 1rem;
+    border: 0.25rem solid transparent;
+  }
 `;


### PR DESCRIPTION
## 작업 내용
- 커스텀 스크롤바 구현
  <img width="1440" alt="image" src="https://user-images.githubusercontent.com/67825309/204444393-85b8c935-853f-4a54-8829-b166a6a8e6fc.png">

## 전달 사항
- global로 구현한 스크롤바입니다.
- 스크롤이 필요한 경우, 가급적 `overflow: overlay`를 추천드립니다.
   > 해당 옵션은 스크롤바가 영역을 차지하지 않도록 합니다.
- 윈도우에서도 동일하게 보이는지는 확인이 필요합니다.

## 참고 사항
- #29 
