### PR TITLE
[BE] 소켓 연결이 끊길 때 유저 퇴장 정보가 브로드캐스트 되지 않는 버그 수정

### DIFF
--- a/server/src/modules/game-room/game-room.gateway.ts
+++ b/server/src/modules/game-room/game-room.gateway.ts
@@ -81,7 +81,7 @@ export class GameRoomGateway implements OnGatewayInit, OnGatewayConnection, OnGa
   @UsePipes(ValidationPipe)
   @SubscribeMessage("game-room/modify")
   async modify(@ConnectedSocket() socket: Socket, @MessageBody() data: RoomSettingDto) {
-    const roomId = JSON.parse(await this.redis.hget(RedisTableName.SOCKET_ID_TO_USER_INFO, socket.id));
+    const { roomId } = JSON.parse(await this.redis.hget(RedisTableName.SOCKET_ID_TO_USER_INFO, socket.id));
     const room = JSON.parse(await this.redis.hget(RedisTableName.GAME_ROOMS, roomId));
     const newRoom = { ...room, ...data };
 

--- a/server/util/socket.ts
+++ b/server/util/socket.ts
@@ -1,5 +1,0 @@
-import { Socket } from "socket.io";
-
-export const getRoomId = (socket: Socket) => {
-  return [...socket.rooms].filter(value => value !== socket.id)[0];
-};


### PR DESCRIPTION
## 작업 내용

- Redis socket.id - 유저 정보 테이블에 roomId도 같이 저장하도록 코드 수정

## 전달 사항

-

## 참고 사항

- #73 
