### PR TITLE
[FE/BE]  닉네임 설정 및 유저 목록 버그 수정

### DIFF
--- a/client/src/components/Modal/NickNameSetting/index.tsx
+++ b/client/src/components/Modal/NickNameSetting/index.tsx
@@ -4,6 +4,10 @@ import Input from "../../Input";
 import Button from "../../Button";
 import { useState } from "react";
 import { updateNickname } from "../../../api/user";
+import { useRecoilState } from "recoil";
+import { userState } from "../../../store/user";
+import { useTheme } from "@emotion/react";
+import { User } from "@dto";
 
 interface NickNameSettingProps {
   closeModal: () => void;
@@ -11,6 +15,7 @@ interface NickNameSettingProps {
 
 const NickNameSetting = ({ closeModal }: NickNameSettingProps) => {
   const [nickName, setNickName] = useState<string>("");
+  const [user, setUser] = useRecoilState(userState);
 
   const handleSubmitButton = () => {
     if (nickName === "") {
@@ -18,10 +23,15 @@ const NickNameSetting = ({ closeModal }: NickNameSettingProps) => {
       return;
     }
 
-    updateNickname(nickName).catch(err => {
-      alert("닉네임 설정에 실패하였습니다.");
-      return;
-    });
+    updateNickname(nickName)
+      .catch(err => {
+        alert("닉네임 설정에 실패하였습니다.");
+        return;
+      })
+      .then(data => {
+        // console.log(user);
+        setUser({ ...(user as User), nickname: data.nickname });
+      });
     alert("닉네임 설정이 완료되었습니다.");
 
     closeModal();

--- a/client/src/components/Modal/NickNameSetting/index.tsx
+++ b/client/src/components/Modal/NickNameSetting/index.tsx
@@ -29,7 +29,6 @@ const NickNameSetting = ({ closeModal }: NickNameSettingProps) => {
         return;
       })
       .then(data => {
-        // console.log(user);
         setUser({ ...(user as User), nickname: data.nickname });
       });
     alert("닉네임 설정이 완료되었습니다.");


### PR DESCRIPTION
## 작업 내용

- 최초 닉네임 설정이 새로고침 전까지 반영되지 않는 문제와 접속 종료한 유저가 유저 목록에서 사라지지 않는 버그 해결

## 전달 사항

- 서버 쪽에는 Redis 테이블 갱신이 제대로 이루어지지 않는 문제가 있었고
- 클라이언트 쪽에는 새로운 유저 정보를 유저 state에 반영하지 않는 문제가 있었습니다.
- 추가적으로, nest 시작시 Redis DB를 비우는 코드를 주석 처리 했습니다. 각자 작업을 할 때 방해가 많이 되는 것 같습니다.

## 참고 사항

- #86 
