### PR TITLE
[FE] 게임 도중 방나가기 시 scoreState 초기화

### DIFF
--- a/client/src/components/Game/CatchMind/index.tsx
+++ b/client/src/components/Game/CatchMind/index.tsx
@@ -319,6 +319,7 @@ export default function CatchMind({ participants }: CatchMindProps) {
   }, [startDrawing, onDrawing, stopDrawing, stateRef.current, drawerId]);
 
   useEffect(() => {
+    setCurrentScore(null);
     if (!canvasRef.current) return;
     const canvas = canvasRef.current;
     canvas.width = 800;


### PR DESCRIPTION

## 작업 내용

- 현재 게임이 정상적으로 끝나면 Recoil에 상태관리되고 있는 현재 점수가 초기화 되지만,
- 게임 도중에 방 나가기 또는 브라우저를 닫아서 나갔을 시에 상태가 초기화 되지 않는다.
- 중간에 나가더라도 상태가 초기화 하도록 만든다.

- 코드 한 줄 추가했습니다.

## 전달 사항

-

## 참고 사항

-
