### PR TITLE
[BE] 특정 시나리오에서 발생하는 버그 해결

### DIFF
--- a/server/src/modules/play/catch-mind.service.ts
+++ b/server/src/modules/play/catch-mind.service.ts
@@ -21,7 +21,8 @@ export class CatchMindService {
     await this.redis.setTo(RedisTableName.PLAY_DATA, roomId, { ...record, state: CatchMindState.WAIT });
     const room: CatchMindGameRoom = await this.redis.getFrom(RedisTableName.GAME_ROOMS, roomId);
     if (!room) return;
-    const { drawerIndex, round, scores, totalScores, answer, playId } = record;
+    const { round, scores, totalScores, answer, playId } = record;
+    const drawerIndex = (record.drawerIndex + room.participants.length) % room.participants.length;
     const drawerId = room.participants[drawerIndex].userId;
 
     const newScores = {};
@@ -33,7 +34,11 @@ export class CatchMindService {
       newTotalScores[userId] = totalScores[userId];
     });
 
-    await this.redis.updateTo(RedisTableName.PLAY_DATA, roomId, { scores: newScores, totalScores: newTotalScores });
+    await this.redis.updateTo(RedisTableName.PLAY_DATA, roomId, {
+      drawerIndex,
+      scores: newScores,
+      totalScores: newTotalScores,
+    });
 
     const resp = {
       round,


### PR DESCRIPTION
## 작업 내용

-  특정 시나리오에서 발생하는 버그 픽스

## 전달 사항

- 시나리오: 2명이 게임중, 게임 결과를 보여주는 상태, 그림을 그리고 있는 사람이 0번 index, 그림을 그리고 있지 않은 사람이 1번 index, 그림을 그리고 있지 않은 사람이 탈주
- 문제 상황: drawerIndex가 1이 되고 room.participants의 길이도 1이 되어 drawerId를 결정하지 못함
- 해결 방법: notifyRoundStart 함수에서 drawerIndex에 나머지 연산 적용, record update시 갱신된 drawerIndex 정보 추가

## 참고 사항

- #133 
