### PR TITLE
[FE / BE] 방 설정 변경 기능 추가

### DIFF
--- a/client/src/components/Modal/RoomSetting/index.tsx
+++ b/client/src/components/Modal/RoomSetting/index.tsx
@@ -8,10 +8,11 @@ import { useRecoilValue } from "recoil";
 import { socketState } from "../../../store/socket";
 
 interface RoomSettingProps {
+  mode: "CREATE" | "MODIFY";
   closeModal: () => void;
 }
 
-const RoomSetting = ({ closeModal }: RoomSettingProps) => {
+const RoomSetting = ({ mode, closeModal }: RoomSettingProps) => {
   const [gameId, setGameId] = useState<number>(-1);
   const [title, setTitle] = useState<string>("");
   const [isPrivate, setIsPrivate] = useState<boolean>(false);
@@ -24,14 +25,21 @@ const RoomSetting = ({ closeModal }: RoomSettingProps) => {
     // room 생성 혹은 설정 로직
     const data = { gameId, title, isPrivate, maximumPeople, password };
 
-    socket.emit("game-room/create", data);
+    if (mode === "CREATE") {
+      socket.emit("game-room/create", data);
+    } else {
+      socket.emit("game-room/modify", data);
+    }
   };
 
   useEffect(() => {
     socket.on("game-room/create-success", () => {
       closeModal();
     });
-  }, [socket]);
+    socket.on("game-room/modify-success", () => {
+      closeModal();
+    });
+  }, [socket, closeModal]);
 
   return (
     <>

--- a/client/src/components/Modal/RoomSetting/index.tsx
+++ b/client/src/components/Modal/RoomSetting/index.tsx
@@ -32,15 +32,6 @@ const RoomSetting = ({ mode, closeModal }: RoomSettingProps) => {
     }
   };
 
-  useEffect(() => {
-    socket.on("game-room/create-success", () => {
-      closeModal();
-    });
-    socket.on("game-room/modify-success", () => {
-      closeModal();
-    });
-  }, [socket, closeModal]);
-
   return (
     <>
       <aside css={style.modalContents}>

--- a/client/src/components/Modal/index.tsx
+++ b/client/src/components/Modal/index.tsx
@@ -14,10 +14,11 @@ export interface ModalProps {
   gameId?: number;
   roomName?: string;
   roomId?: string;
+  roomSettingMode?: "CREATE" | "MODIFY";
   closeModal: () => void;
 }
 
-const Modal = ({ ModalType, user, gameId, roomName, closeModal, roomId }: ModalProps) => {
+const Modal = ({ ModalType, user, gameId, roomName, closeModal, roomId, roomSettingMode }: ModalProps) => {
   let modalTitle = "";
   let content = null;
 
@@ -28,7 +29,7 @@ const Modal = ({ ModalType, user, gameId, roomName, closeModal, roomId }: ModalP
       break;
     case "방 설정":
       modalTitle = "방 설정";
-      content = <RoomSetting closeModal={closeModal} />;
+      content = <RoomSetting closeModal={closeModal} mode={roomSettingMode!} />;
       break;
     case "비밀번호 입력":
       modalTitle = "비밀번호 입력";

--- a/client/src/components/RoomList/index.tsx
+++ b/client/src/components/RoomList/index.tsx
@@ -96,7 +96,9 @@ const RoomList = ({ rooms }: RoomListProps) => {
           <Select selectType="게임 필터" setValue={setGameType} />
         </div>
         <Button buttonType="방 만들기" handleClick={() => setCreateRoomModalOpen(true)} />
-        {createRoomModalOpen && <Modal ModalType="방 설정" closeModal={() => setCreateRoomModalOpen(false)} />}
+        {createRoomModalOpen && (
+          <Modal ModalType="방 설정" closeModal={() => setCreateRoomModalOpen(false)} roomSettingMode="CREATE" />
+        )}
       </div>
 
       <div css={style.roomListStyle}>

--- a/client/src/components/RoomList/index.tsx
+++ b/client/src/components/RoomList/index.tsx
@@ -62,12 +62,15 @@ const RoomList = ({ rooms }: RoomListProps) => {
 
   useEffect(() => {
     socket.on("game-room/create-success", data => {
+      setCreateRoomModalOpen(false);
       navigate(`/waiting/${data.roomId}`);
     });
     socket.on("game-room/password-success", data => {
+      setPasswordModalOpen(false);
       navigate(`/waiting/${data.roomId}`);
     });
-    socket.on("game-room/password-failed", data => {
+    socket.on("game-room/password-failed", () => {
+      setPasswordModalOpen(false);
       alert("비밀번호가 틀렸습니다.");
     });
 

--- a/client/src/components/WaitingRoomInfo/index.tsx
+++ b/client/src/components/WaitingRoomInfo/index.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useRecoilValue } from "recoil";
 import { socketState } from "../../store/socket";
@@ -12,6 +12,7 @@ import * as style from "./styles";
 import { User } from "@dto";
 import { useCams } from "../../hooks/useCams";
 import { userState } from "../../store/user";
+import Modal from "../Modal";
 
 export interface WaitingRoomInfoProps {
   roomRecord: Room;
@@ -27,6 +28,12 @@ const WaitingRoomInfo = ({ roomRecord, participants }: WaitingRoomInfoProps) => 
   const user = useRecoilValue(userState);
   const navigate = useNavigate();
   const { videoStream, audioStream } = useCams();
+
+  const [modifyRoomModalOpen, setModifyRoomModalOpen] = useState<boolean>(false);
+
+  const handleRoomRecordClick = () => {
+    setModifyRoomModalOpen(true);
+  };
 
   const handleRootOutButton = () => {
     navigate("/lobby");
@@ -51,10 +58,28 @@ const WaitingRoomInfo = ({ roomRecord, participants }: WaitingRoomInfoProps) => 
     };
   }, [socket, navigate, roomRecord]);
 
+  useEffect(() => {
+    socket.on("game-room/password-failed", data => {
+      alert("비밀번호가 틀렸습니다.");
+    });
+
+    socket.on("game-room/error", errorMessage => {
+      alert(errorMessage);
+    });
+
+    return () => {
+      socket.off("game-room/password-failed");
+      socket.off("game-room/error");
+    };
+  }, [socket]);
+
   return (
     <div css={style.waitingRoomInfoStyle}>
       <div css={style.headerStyle}>
-        <RoomRecord {...roomRecord} />
+        <RoomRecord {...roomRecord} onClickRecord={handleRoomRecordClick} />
+        {modifyRoomModalOpen && (
+          <Modal ModalType="방 설정" closeModal={() => setModifyRoomModalOpen(false)} roomSettingMode="MODIFY" />
+        )}
       </div>
       <div css={style.mainWrapperStyle}>
         <div css={style.camListContainerStyle}>

--- a/client/src/components/WaitingRoomInfo/index.tsx
+++ b/client/src/components/WaitingRoomInfo/index.tsx
@@ -59,16 +59,11 @@ const WaitingRoomInfo = ({ roomRecord, participants }: WaitingRoomInfoProps) => 
   }, [socket, navigate, roomRecord]);
 
   useEffect(() => {
-    socket.on("game-room/password-failed", () => {
-      alert("비밀번호가 틀렸습니다.");
-    });
-
     socket.on("game-room/error", errorMessage => {
       alert(errorMessage);
     });
 
     return () => {
-      socket.off("game-room/password-failed");
       socket.off("game-room/error");
     };
   }, [socket]);

--- a/client/src/components/WaitingRoomInfo/index.tsx
+++ b/client/src/components/WaitingRoomInfo/index.tsx
@@ -59,7 +59,7 @@ const WaitingRoomInfo = ({ roomRecord, participants }: WaitingRoomInfoProps) => 
   }, [socket, navigate, roomRecord]);
 
   useEffect(() => {
-    socket.on("game-room/password-failed", data => {
+    socket.on("game-room/password-failed", () => {
       alert("비밀번호가 틀렸습니다.");
     });
 

--- a/server/src/modules/game-room/game-room.gateway.ts
+++ b/server/src/modules/game-room/game-room.gateway.ts
@@ -95,8 +95,18 @@ export class GameRoomGateway implements OnGatewayInit {
   @UsePipes(ValidationPipe)
   @SubscribeMessage("game-room/modify")
   async modify(@ConnectedSocket() socket: Socket, @MessageBody() data: RoomSettingDto) {
-    const { roomId } = await this.redis.getFrom(RedisTableName.SOCKET_ID_TO_USER_INFO, socket.id);
+    const { isPrivate, password } = data;
+
+    if (isPrivate && !(password.length >= 1 && password.length <= 20)) {
+      throw new SocketException("game-room/error", "비밀번호는 1자 이상 20자 이하여야만 합니다.");
+    }
+
+    const user = await this.redis.getFrom(RedisTableName.SOCKET_ID_TO_USER_INFO, socket.id);
+    if (!user) return;
+    const { roomId } = user;
+    if (!roomId) return;
     const room = await this.redis.getFrom(RedisTableName.GAME_ROOMS, roomId);
+    if (!room) return;
     const newRoom = { ...room, ...data };
 
     // 방 설정 변경
@@ -107,6 +117,8 @@ export class GameRoomGateway implements OnGatewayInit {
       roomId,
       ...newRoom,
     });
+
+    socket.emit("game-room/modify-success", { roomId });
   }
 
   @UsePipes(ValidationPipe)

--- a/server/src/modules/game-room/game-room.gateway.ts
+++ b/server/src/modules/game-room/game-room.gateway.ts
@@ -102,11 +102,11 @@ export class GameRoomGateway implements OnGatewayInit {
     }
 
     const user = await this.redis.getFrom(RedisTableName.SOCKET_ID_TO_USER_INFO, socket.id);
-    if (!user) return;
+    if (!user) throw new SocketException("game-room/error", "유저 정보가 존재하지 않습니다.");
     const { roomId } = user;
-    if (!roomId) return;
+    if (!roomId) throw new SocketException("game-room/error", "방에 입장해있는 유저만 방 설정을 변경할 수 있습니다.");
     const room = await this.redis.getFrom(RedisTableName.GAME_ROOMS, roomId);
-    if (!room) return;
+    if (!room) throw new SocketException("game-room/error", "방에 입장해있는 유저만 방 설정을 변경할 수 있습니다.");
     const newRoom = { ...room, ...data };
 
     // 방 설정 변경


### PR DESCRIPTION
## 작업 내용

- 방 내부에서 헤더 클릭시 방 설정 변경 모달이 뜨도록 구현
- 방 설정 변경 모달에서 내용을 입력하고 확인 버튼을 누르면 방 설정이 변경되도록 구현

## 전달 사항

- RoomSetting 모달에 props를 하나 추가했습니다.
- WaitingRoomInfo 컴포넌트에 방 설정 관련 에러 처리 이벤트를 바인딩 했습니다.
- 백엔드 방 설정 변경 로직을 수정했습니다.

## 참고 사항

- #134 
