### PR TITLE
[FE / BE] 랭킹 관련 기능 추가

### DIFF
--- a/client/src/api/user.ts
+++ b/client/src/api/user.ts
@@ -9,6 +9,15 @@ export const getLoggedInUser = async () => {
   }
 };
 
+export const getTopUsers = async () => {
+  try {
+    const res = await axios.get("/user/top");
+    return res.data;
+  } catch {
+    return null;
+  }
+};
+
 export const updateNickname = async (nickname: string) => {
   try {
     const res = await axios.patch("/user/nickname", { nickname });

--- a/client/src/components/Profile/ProfileContent/index.tsx
+++ b/client/src/components/Profile/ProfileContent/index.tsx
@@ -35,7 +35,7 @@ const ProfileContent = ({ user, editable, setNicknameChangeModalOpen }: ProfileP
         </div>
         <p css={style.ProfileEmailStyle}>{user.email}</p>
         <p css={style.ProfileScoreStyle}>
-          {user.score} 점 ( {user.rank} 위 )
+          {user.score} 점 <span>( {user.rank} 위 )</span>
         </p>
       </div>
     </div>

--- a/client/src/components/Profile/ProfileContent/styles.ts
+++ b/client/src/components/Profile/ProfileContent/styles.ts
@@ -65,4 +65,10 @@ export const ProfileScoreStyle = css`
   font-size: 0.8rem;
   font-weight: bold;
   margin-top: 1.25rem;
+
+  > span {
+    font-size: 0.8rem;
+    font-weight: bold;
+    color: mediumseagreen;
+  }
 `;

--- a/client/src/components/UserList/UserListTab/styles.ts
+++ b/client/src/components/UserList/UserListTab/styles.ts
@@ -5,6 +5,12 @@ export const TabContainerStyle = css`
   flex-direction: row;
   align-items: flex-end;
   margin-left: 0.75rem;
+
+  > li {
+    &:hover {
+      cursor: pointer;
+    }
+  }
 `;
 
 export const TabStyle = css`

--- a/client/src/components/UserList/index.tsx
+++ b/client/src/components/UserList/index.tsx
@@ -6,6 +6,7 @@ import { useRecoilValue } from "recoil";
 import { socketState } from "../../store/socket";
 import * as style from "./styles";
 import Spinner from "../Loader/Spinner";
+import { getTopUsers } from "../../api/user";
 
 export type User = {
   userId: number;
@@ -19,7 +20,7 @@ export type User = {
 export interface UserListProps {
   users: User[];
   friends: User[];
-  rank: User[];
+  topUsers: User[];
 }
 
 const UserList = () => {
@@ -29,7 +30,7 @@ const UserList = () => {
   const [userMap, setUserMap] = useState<UserListProps>({
     users: [],
     friends: [],
-    rank: [],
+    topUsers: [],
   });
 
   useEffect(() => {
@@ -44,6 +45,16 @@ const UserList = () => {
     };
   }, [socket]);
 
+  useEffect(() => {
+    if (selected === 2) {
+      getTopUsers().then(topUsers => {
+        setUserMap(current => {
+          return { ...current, topUsers };
+        });
+      });
+    }
+  }, [selected]);
+
   return (
     <div css={style.ListContainerStyle}>
       <UserListTab selected={selected} setSelected={setSelected} />
@@ -55,7 +66,7 @@ const UserList = () => {
           <>
             {selected === 0 && <UserTable users={userMap.users} selected={selected} />}
             {selected === 1 && <UserTable users={userMap.friends} selected={selected} />}
-            {selected === 2 && <UserTable users={userMap.rank} selected={selected} />}
+            {selected === 2 && <UserTable users={userMap.topUsers} selected={selected} />}
           </>
         )}
       </div>

--- a/client/src/components/UserList/index.tsx
+++ b/client/src/components/UserList/index.tsx
@@ -47,10 +47,12 @@ const UserList = () => {
 
   useEffect(() => {
     if (selected === 2) {
+      setLoading(true);
       getTopUsers().then(topUsers => {
         setUserMap(current => {
           return { ...current, topUsers };
         });
+        setLoading(false);
       });
     }
   }, [selected]);

--- a/server/src/modules/user/user.controller.ts
+++ b/server/src/modules/user/user.controller.ts
@@ -26,9 +26,9 @@ export class UserController {
     return this.userService.findUser(req.user.userId);
   }
 
-  @Get("/list")
-  async getUserList() {
-    return this.userService.findAllUser();
+  @Get("/top")
+  async getTopUsers() {
+    return this.userService.findTopTenUser();
   }
 
   @UsePipes(ValidationPipe)

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -20,8 +20,20 @@ export class UserService {
       where: { userId: id },
       select: getUserOption,
     });
+
     if (!userInfo) throw new NotFoundException();
-    return userInfo;
+
+    // 랭킹을 구한다.
+    const rank =
+      (await this.prisma.user.count({
+        where: {
+          score: {
+            gt: userInfo.score,
+          },
+        },
+      })) + 1;
+
+    return { ...userInfo, rank };
   }
 
   async findTopTenUser() {


### PR DESCRIPTION
## 작업 내용
- 유저 목록 랭킹 탭에 상위 10명의 유저가 표시되는 기능 구현
- 프로필에 자신의 랭킹 표시

## 전달 사항

- 랭킹 탭에까지 실시간성을 준다면 오버헤드가 너무 커질 것 같다는 판단이 들어서 랭킹 탭을 클릭할 때 서버에게 요청이 가고 서버가 DB를 조회해 응답을 하는 방식으로 구현을 했습니다. 유저 입장에서 랭킹이 궁금할 때만 랭킹 탭을 클릭할 확률이 높기 때문에 사용자에게 불편을 줄 일은 크게 없어 보입니다.

## 참고 사항

- #144 
