### PR TITLE
[FE] 뷰 포트에 맞추어 html font-size 지정, 컴포넌트 사이즈 조정

### DIFF
--- a/client/src/components/Button/styles.ts
+++ b/client/src/components/Button/styles.ts
@@ -7,12 +7,12 @@ export const largeButtonStyle = css`
     transition: all 0.3s;
   }
 
-  border-radius: 10px;
+  border-radius: 0.6rem;
   box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.2);
   width: 8rem;
   height: 2.5rem;
 
-  padding-top: 3px; // 글자를 가운데로 정렬하는 용도
+  padding-top: 0.2rem; // 글자를 가운데로 정렬하는 용도
   font-weight: bold;
 `;
 
@@ -23,30 +23,30 @@ export const smallButtonStyle = css`
     transition: all 0.3s;
   }
 
-  border: 1px solid black;
-  border-radius: 5px;
+  border: 0.1rem solid black;
+  border-radius: 0.3rem;
   box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.2);
 
   width: 3.5rem;
   height: 1.5rem;
 
-  padding-top: 3px; // 글자를 가운데로 정렬하는 용도
+  padding-top: 0.2rem; // 글자를 가운데로 정렬하는 용도
   font-weight: bold;
 `;
 
 export const gameStartButtonStyle = css`
   background: #ec7171;
-  border: 1px solid #ffbaba;
+  border: 0.1rem solid #ffbaba;
 `;
 
 export const createRoomButtonStyle = css`
   background: #ec7171;
-  border: 1px solid #ffbaba;
+  border: 0.1rem solid #ffbaba;
 `;
 
 export const exitRoomButtonStyle = css`
   background: #d6fc84;
-  border: 1px solid #e1ffba;
+  border: 0.1rem solid #e1ffba;
 `;
 
 export const acceptButtonStyle = css`

--- a/client/src/components/Button/styles.ts
+++ b/client/src/components/Button/styles.ts
@@ -12,7 +12,6 @@ export const largeButtonStyle = css`
   width: 8rem;
   height: 2.5rem;
 
-  padding-top: 0.2rem; // 글자를 가운데로 정렬하는 용도
   font-weight: bold;
 `;
 
@@ -30,7 +29,6 @@ export const smallButtonStyle = css`
   width: 3.5rem;
   height: 1.5rem;
 
-  padding-top: 0.2rem; // 글자를 가운데로 정렬하는 용도
   font-weight: bold;
 `;
 

--- a/client/src/components/Cam/styles.ts
+++ b/client/src/components/Cam/styles.ts
@@ -7,7 +7,7 @@ export const camContainerStyle = css`
   gap: 0.5rem;
 
   > span {
-    font-size: 18px;
+    font-size: 1.1rem;
     font-weight: bold;
   }
 `;
@@ -18,7 +18,7 @@ export const camNickNameStyle = css`
 
 export const camScoreStyle = css`
   color: green;
-  font-size: 16px;
+  font-size: 1rem;
 `;
 
 export const camWrapperStyle = css`
@@ -28,8 +28,8 @@ export const camWrapperStyle = css`
 
   position: relative;
   background-color: black;
-  border-radius: 10px;
-  border: 1px solid green;
+  border-radius: 0.6rem;
+  border: 0.1rem solid green;
   overflow: hidden;
 
   width: 10rem;

--- a/client/src/components/Cam/styles.ts
+++ b/client/src/components/Cam/styles.ts
@@ -5,6 +5,7 @@ export const camContainerStyle = css`
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
+  width: 100%;
 
   > span {
     font-size: 1.1rem;
@@ -32,7 +33,7 @@ export const camWrapperStyle = css`
   border: 0.1rem solid green;
   overflow: hidden;
 
-  width: 10rem;
+  width: 12rem;
   aspect-ratio: 4/3;
 
   > video {

--- a/client/src/components/Chatting/ChatInput/index.tsx
+++ b/client/src/components/Chatting/ChatInput/index.tsx
@@ -47,7 +47,7 @@ const ChatInput = ({ addLogs, socket, channel }: ChatInputProps) => {
         handleKeyPress={pressEnter}
         width={"95%"}
       />
-      <img src={chatInputEnter} alt="chatLogEnter" onClick={sendMessage} />
+      <img css={style.ChatInputSubmitButtonStyle} src={chatInputEnter} alt="chatLogEnter" onClick={sendMessage} />
     </div>
   );
 };

--- a/client/src/components/Chatting/ChatInput/styles.ts
+++ b/client/src/components/Chatting/ChatInput/styles.ts
@@ -4,4 +4,9 @@ export const ChatInputContainerStyle = css`
   display: flex;
   justify-content: space-between;
   width: 100%;
+  height: 2rem;
+`;
+
+export const ChatInputSubmitButtonStyle = css`
+  height: 100%;
 `;

--- a/client/src/components/Chatting/ChatLog/styles.ts
+++ b/client/src/components/Chatting/ChatLog/styles.ts
@@ -17,4 +17,5 @@ export const ChatLogContainerStyle = css`
 export const ChatLogStyle = css`
   display: flex;
   gap: 0.25rem;
+  word-break: break-all;
 `;

--- a/client/src/components/Chatting/styles.ts
+++ b/client/src/components/Chatting/styles.ts
@@ -2,7 +2,7 @@ import { css, Theme } from "@emotion/react";
 
 export const ChattingContainerStyle = (theme: Theme) => css`
   background-color: ${theme.colors.secondary};
-  width: 60rem;
+  width: 72.5rem;
   height: 12.5rem;
   border-radius: 0.75rem;
   padding: 0.75rem;

--- a/client/src/components/Game/CatchMind/index.tsx
+++ b/client/src/components/Game/CatchMind/index.tsx
@@ -14,7 +14,7 @@ import paletteLockIcon from "../../../assets/icons/palette-lock.png";
 import { useNavigate, useLocation } from "react-router-dom";
 import { User } from "@dto";
 
-const DEFAULT_FONT = "50px LINESeedKR bold";
+const DEFAULT_FONT = "3rem LINESeedKR bold";
 
 enum Color {
   WHITE = "white",
@@ -119,7 +119,7 @@ export default function CatchMind({ participants }: CatchMindProps) {
       ctx.fillStyle = option?.color ?? "black";
       if (option?.size) {
         ctx.font = option.size + " LINESeedKR";
-      }
+      } else ctx.font = "4rem LINESeedKR";
 
       const metrics = ctx.measureText(text);
       const width = metrics.width;
@@ -167,6 +167,16 @@ export default function CatchMind({ participants }: CatchMindProps) {
     },
     [isDrawing, getContextObject, handleDebounce]
   );
+
+  const resizeCanvas = () => {
+    if (!canvasRef.current) return;
+    const canvas = canvasRef.current;
+
+    if (canvas.parentElement) {
+      canvas.width = canvas.parentElement.clientWidth;
+      canvas.height = canvas.parentElement.clientHeight;
+    }
+  };
 
   // event handlers
   const handlePencilMode = useCallback(() => {
@@ -274,7 +284,7 @@ export default function CatchMind({ participants }: CatchMindProps) {
       clearCanvas();
       const ctx = getContextObject();
       writeCenter(`정답 공개`, { color: "black", dx: 0, dy: -90 });
-      writeCenter(`${data.answer}`, { color: "red", size: "75px", dx: 0, dy: 30 });
+      writeCenter(`${data.answer}`, { color: "red", size: "4.5rem", dx: 0, dy: 30 });
       ctx.fillStyle = currentColorRef.current;
 
       setTime(RESULT_TIME);
@@ -320,10 +330,6 @@ export default function CatchMind({ participants }: CatchMindProps) {
 
   useEffect(() => {
     setCurrentScore(null);
-    if (!canvasRef.current) return;
-    const canvas = canvasRef.current;
-    canvas.width = 800;
-    canvas.height = 510;
 
     const ctx = getContextObject();
     ctx.font = DEFAULT_FONT;
@@ -373,6 +379,15 @@ export default function CatchMind({ participants }: CatchMindProps) {
       ctx.strokeStyle = Color.WHITE;
     }
   }, [mode, getContextObject]);
+
+  useEffect(() => {
+    resizeCanvas();
+    window.addEventListener("resize", resizeCanvas);
+
+    return () => {
+      window.removeEventListener("reisez", resizeCanvas);
+    };
+  }, [canvasRef]);
 
   return (
     <div css={style.gameWrapperStyle}>

--- a/client/src/components/Game/CatchMind/index.tsx
+++ b/client/src/components/Game/CatchMind/index.tsx
@@ -172,9 +172,19 @@ export default function CatchMind({ participants }: CatchMindProps) {
     if (!canvasRef.current) return;
     const canvas = canvasRef.current;
 
+    const ctx = getContextObject();
+
+    const canvasBack = document.createElement("canvas");
+    canvasBack.width = canvas.width;
+    canvasBack.height = canvas.height;
+    const ctxBack = canvasBack.getContext("2d");
+    ctxBack?.drawImage(canvas, 0, 0);
+
     if (canvas.parentElement) {
       canvas.width = canvas.parentElement.clientWidth;
       canvas.height = canvas.parentElement.clientHeight;
+
+      ctx.drawImage(canvasBack, 0, 0, canvas.width, canvas.height);
     }
   };
 
@@ -345,7 +355,9 @@ export default function CatchMind({ participants }: CatchMindProps) {
         if (roundRef.current !== data.round) return;
         if (gameState !== CatchMindState.DRAW) return;
         const ctx = getContextObject();
-        ctx.drawImage(image, 0, 0);
+
+        const canvas = canvasRef.current;
+        ctx.drawImage(image, 0, 0, canvas!.width, canvas!.height);
       };
       image.src = data.imageSrc;
     });

--- a/client/src/components/Game/CatchMind/styles.ts
+++ b/client/src/components/Game/CatchMind/styles.ts
@@ -3,7 +3,8 @@ import palleteCoverTexture from "../../../assets/images/oak-texture-background.w
 
 export const gameWrapperStyle = css`
   display: flex;
-  gap: 1rem;
+  gap: 2rem;
+  width: 100%;
 `;
 
 export const paletteLockStyle = css`
@@ -12,13 +13,12 @@ export const paletteLockStyle = css`
   justify-content: center;
   width: 100%;
   height: 100%;
-  border-radius: 5px;
+  border-radius: 0.3rem;
   position: absolute;
   top: -0.1rem;
-  right: -0.1rem;
   z-index: 1;
 
-  border: 1.5px solid burlywood;
+  border: 0.4rem solid burlywood;
   background-image: url(${palleteCoverTexture});
 
   > img {
@@ -29,17 +29,17 @@ export const paletteLockStyle = css`
 
 export const paletteStyle = css`
   position: relative;
-  bottom: 0px;
+  bottom: 0;
 
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
   align-items: center;
 
-  width: 15rem;
+  width: 5rem;
   background-color: burlywood;
-  border: 1px solid black;
-  border-radius: 5px;
+  border: 0.1rem solid black;
+  border-radius: 0.3rem;
 
   box-sizing: content-box;
   padding: 0.5rem;
@@ -52,8 +52,8 @@ export const toolStyle = css`
 `;
 
 export const buttonStyle = (line: string, thisLine: string) => css`
-  border-radius: 5px;
-  ${line === thisLine ? "border: 3px solid green;" : ""}
+  border-radius: 0.3rem;
+  ${line === thisLine ? "border: 0.2rem solid green;" : ""}
 
   box-sizing: border-box;
   width: 4rem;
@@ -68,8 +68,8 @@ export const buttonStyle = (line: string, thisLine: string) => css`
 
 export const clearStyle = css`
   width: 4rem;
-  border-radius: 5px;
-  padding: 3px 0;
+  border-radius: 0.3rem;
+  padding: 0.2rem 0;
   cursor: pointer;
   background-color: plum;
   box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.2);
@@ -81,8 +81,8 @@ export const toggleStyle = (mode: string, thisMode: string) => css`
   width: 4rem;
   height: 4rem;
   box-sizing: border-box;
-  ${mode === thisMode ? "border: 3px solid green;" : ""}
-  border-radius: 5px;
+  ${mode === thisMode ? "border: 0.2rem solid green;" : ""}
+  border-radius: 0.3rem;
   cursor: pointer;
   background-color: plum;
   > img {
@@ -101,7 +101,7 @@ export const lineWidthStyle = css``;
 export const selectedColorStyle = (color: string) => css`
   width: 4rem;
   height: 4rem;
-  border-radius: 5px;
+  border-radius: 0.3rem;
 
   background-color: ${color};
   cursor: pointer;
@@ -120,7 +120,7 @@ export const colorGridStyle = css`
 export const colorStyle = (color: string) => css`
   width: 2rem;
   height: 2rem;
-  border-radius: 5px;
+  border-radius: 0.3rem;
 
   background-color: ${color};
   cursor: pointer;
@@ -131,10 +131,12 @@ export const gameViewStyle = css`
   flex-direction: column;
   gap: 1rem;
   padding: 0;
+  /* flex-grow: 1; */
+  width: calc(100% - 8rem);
 `;
 
 export const canvasStyle = css`
-  border: 1px solid black;
+  border: 0.1rem solid black;
   background-color: white;
   width: 100%;
   height: 32rem;

--- a/client/src/components/Header/Logout/index.tsx
+++ b/client/src/components/Header/Logout/index.tsx
@@ -20,7 +20,7 @@ const RoomRecord = () => {
 
   return (
     <div css={style.logoutContainerStyle} onClick={handleLogout}>
-      <img src={logoutIcon} alt="logoutIcon" />
+      <img css={style.logoutIconStyle} src={logoutIcon} alt="logoutIcon" />
       <span css={style.logoutTextStyle}>로그아웃</span>
     </div>
   );

--- a/client/src/components/Header/Logout/styles.ts
+++ b/client/src/components/Header/Logout/styles.ts
@@ -15,3 +15,7 @@ export const logoutContainerStyle = css`
     filter: invert(50%);
   }
 `;
+
+export const logoutIconStyle = css`
+  height: 1.5rem;
+`;

--- a/client/src/components/Header/StatusMedia/index.tsx
+++ b/client/src/components/Header/StatusMedia/index.tsx
@@ -22,7 +22,11 @@ const StatusMedia = () => {
             stream.getAudioTracks()[0].enabled = !stream.getAudioTracks()[0].enabled;
           }}
         >
-          {audio ? <img src={micOn} alt="micOn" /> : <img src={micOff} alt="micOff" />}
+          {audio ? (
+            <img css={style.micIconStyle} src={micOn} alt="micOn" />
+          ) : (
+            <img css={style.micIconStyle} src={micOff} alt="micOff" />
+          )}
         </div>
         <div
           css={style.micCamButtonStyle}
@@ -31,7 +35,11 @@ const StatusMedia = () => {
             stream.getVideoTracks()[0].enabled = !stream.getVideoTracks()[0].enabled;
           }}
         >
-          {video ? <img src={camOn} alt="camOn" /> : <img src={camOff} alt="camOff" />}
+          {video ? (
+            <img css={style.micIconStyle} src={camOn} alt="camOn" />
+          ) : (
+            <img css={style.micIconStyle} src={camOff} alt="camOff" />
+          )}
         </div>
       </div>
     )

--- a/client/src/components/Header/StatusMedia/styles.ts
+++ b/client/src/components/Header/StatusMedia/styles.ts
@@ -19,3 +19,7 @@ export const micCamButtonStyle = css`
     filter: invert(50%);
   }
 `;
+
+export const micIconStyle = css`
+  width: 3rem;
+`;

--- a/client/src/components/Header/styles.ts
+++ b/client/src/components/Header/styles.ts
@@ -18,7 +18,7 @@ export const audioControllerStyle = css`
   justify-content: flex-start;
   width: 15rem;
   height: 3rem;
-  border: 1px solid green;
+  border: 0.1rem solid green;
   margin-left: 2rem;
   box-sizing: border-box;
   overflow: hidden;
@@ -26,7 +26,7 @@ export const audioControllerStyle = css`
   background-color: rgba(0, 0, 0, 0.7);
 
   > p {
-    font-size: large;
+    font-size: 1.1rem;
     color: lightgreen;
     animation: marquee 5s linear infinite;
 

--- a/client/src/components/InGameCamList/styles.ts
+++ b/client/src/components/InGameCamList/styles.ts
@@ -10,7 +10,7 @@ export const inGameCamListStyle = css`
 
 export const camWrapperStyle = (theme: Theme) => css`
   padding: 0.5rem;
-  border-radius: 10px;
+  border-radius: 0.6rem;
   box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.2);
   background-color: ${theme.colors.secondary};
 `;

--- a/client/src/components/InGameComponent/styles.tsx
+++ b/client/src/components/InGameComponent/styles.tsx
@@ -18,7 +18,7 @@ export const GameAndChatContainerStyle = css`
 export const GameContainerStyle = (theme: Theme) => css`
   background-color: ${theme.colors.secondary};
   height: 40rem;
-  width: 60rem;
+  width: 72.5rem;
   border-radius: 0.75rem;
   text-align: center;
   padding: 2rem;

--- a/client/src/components/Logo/index.tsx
+++ b/client/src/components/Logo/index.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { logoStyle } from "./styles";
+import { logoIconStyle, logoStyle, logoWordStyle } from "./styles";
 import JapariLogoGame from "../../assets/logo/japari-logo-image.svg";
 import JapariLogoWord from "../../assets/logo/japari-logo-word.svg";
 
@@ -26,8 +26,8 @@ const Logo = ({ logoType }: LogoProps) => {
 
   return (
     <div css={logoStyle}>
-      <img src={JapariLogoGame} alt="JapariLogoGame" />
-      <img src={JapariLogoWord} alt="JapariLogoWord" />
+      <img css={logoIconStyle} src={JapariLogoGame} alt="JapariLogoGame" />
+      <img css={logoWordStyle} src={JapariLogoWord} alt="JapariLogoWord" />
     </div>
   );
 };

--- a/client/src/components/Logo/styles.ts
+++ b/client/src/components/Logo/styles.ts
@@ -2,7 +2,15 @@ import { css } from "@emotion/react";
 
 export const logoStyle = css`
   display: flex;
-  gap: 5px;
+  gap: 0.3rem;
   align-items: center;
-  height: 50px;
+  height: 3rem;
+`;
+
+export const logoIconStyle = css`
+  height: 100%;
+`;
+
+export const logoWordStyle = css`
+  height: 66%;
 `;

--- a/client/src/components/Profile/styles.ts
+++ b/client/src/components/Profile/styles.ts
@@ -2,7 +2,7 @@ import { css, Theme } from "@emotion/react";
 
 export const ProfileContainerStyle = (theme: Theme) => css`
   background-color: ${theme.colors.secondary};
-  width: 20rem;
+  width: 22.5rem;
   height: 12.5rem;
   border-radius: 0.75rem;
   box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.2);

--- a/client/src/components/RoomList/RoomRecord/styles.ts
+++ b/client/src/components/RoomList/RoomRecord/styles.ts
@@ -13,10 +13,10 @@ export const roomRecordStyle = css`
   padding: 0.75rem 0rem;
 
   background: #5992ff;
-  border-radius: 5px;
+  border-radius: 0.3rem;
 
   > span {
-    font-size: 18px;
+    font-size: 1.1rem;
     font-weight: bold;
     color: white;
 
@@ -49,5 +49,5 @@ export const roomRecordPeopleStyle = css`
 export const divisionLineStyle = css`
   background-color: white;
   width: 0.2rem;
-  border-radius: 5px;
+  border-radius: 0.3rem;
 `;

--- a/client/src/components/RoomList/styles.ts
+++ b/client/src/components/RoomList/styles.ts
@@ -5,7 +5,7 @@ export const containerStyle = css`
   display: inline-flex;
   flex-direction: column;
   height: 40rem;
-  width: 60rem;
+  width: 72.5rem;
 `;
 
 export const headerStyle = css`
@@ -38,7 +38,7 @@ export const roomListStyle = (theme: Theme) => css`
   flex-grow: 1;
   box-sizing: border-box;
   padding: 1.5rem;
-  border-radius: 10px;
+  border-radius: 0.6rem;
   overflow-y: overlay;
 
   box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.2);

--- a/client/src/components/UserList/styles.ts
+++ b/client/src/components/UserList/styles.ts
@@ -3,7 +3,7 @@ import { css, Theme } from "@emotion/react";
 export const ListContainerStyle = css`
   display: flex;
   flex-direction: column;
-  width: 20rem;
+  width: 22.5rem;
   height: 40rem;
 `;
 

--- a/client/src/components/WaitingRoomInfo/styles.ts
+++ b/client/src/components/WaitingRoomInfo/styles.ts
@@ -54,7 +54,7 @@ export const camBoxStyle = css`
 `;
 
 export const micStyle = css`
-  width: 1rem;
+  width: 1.5rem;
   z-index: 1;
   position: absolute;
   left: 75%;

--- a/client/src/components/WaitingRoomInfo/styles.ts
+++ b/client/src/components/WaitingRoomInfo/styles.ts
@@ -3,7 +3,7 @@ import { css, Theme } from "@emotion/react";
 export const waitingRoomInfoStyle = css`
   display: flex;
   flex-direction: column;
-  width: 60rem;
+  width: 72.5rem;
   height: 40rem;
 `;
 
@@ -14,7 +14,7 @@ export const headerStyle = css`
   height: 3rem;
 
   > div {
-    border-radius: 5px 5px 0 0;
+    border-radius: 0.3rem 0.3rem 0 0;
   }
 `;
 
@@ -27,7 +27,7 @@ export const mainWrapperStyle = (theme: Theme) => css`
   gap: 2rem;
   padding: 3rem;
   box-sizing: border-box;
-  border-radius: 10px;
+  border-radius: 0.6rem;
   box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.2);
   background-color: ${theme.colors.secondary};
 `;

--- a/client/src/pages/lobby/styles.ts
+++ b/client/src/pages/lobby/styles.ts
@@ -5,7 +5,7 @@ export const LobbyContentContainerStyle = css`
   flex-direction: column;
   align-items: center;
   gap: 2rem;
-  padding: 1rem 1rem 2rem 1rem;
+  padding: 1rem 1.5rem 2rem 1.5rem;
 `;
 
 export const RowContentContainerStyle = css`

--- a/client/src/styles/global.ts
+++ b/client/src/styles/global.ts
@@ -171,7 +171,7 @@ export const globalStyle = css`
 
   * {
     font-family: "LINESeedKR";
-    font-size: 16px;
+    font-size: max(8px, min(1vw, 100vh / 62));
   }
 
   body {


### PR DESCRIPTION
## 작업 내용
- 뷰 포트에 맞추어 html font-size 지정
- 전반적인 컴포넌트 사이즈 조정
- px -> rem으로 통일

## 전달 사항
- font-size: max(8px, min(1vw, 100vh / 62));
  - 컴포넌트의 가로를 100rem, 세로를 62rem으로 통일 후 뷰 포트에 맞추어 font-size 지정
  - 무한히 확대해도 화면이 그대로 유지되는 걸 방지하기 위해 8px 이상은 유지하도록 설정
- 캐치마인드의 경우 canvas의 크기를 반응형으로 만들기 위해 canvas.parentElement의 size를 부여
  - 'resize' 이벤트를 listening하여 화면 크기가 바뀌어도 깨지지 않게 처리
- 혹시 모르니 테스트 한 번씩은 부탁드립니다.

## 참고 사항
- #151 
